### PR TITLE
LIN-3116 Check Dispatched Flag when Status = Dispatched

### DIFF
--- a/app/views/issues/_attributes.rhtml
+++ b/app/views/issues/_attributes.rhtml
@@ -1136,7 +1136,7 @@ Event.observe(window, 'load', function() {
       setDueDate(null)
     else if (label == 'Dispatched') {
       const dispatchedCheckbox = findInput("Dispatched", "input[type=checkbox]");
-      dispatchedCheckbox.checked = true;
+      if (dispatchedCheckbox) dispatchedCheckbox.checked = true;
     }
   })
 })

--- a/app/views/issues/_attributes.rhtml
+++ b/app/views/issues/_attributes.rhtml
@@ -1134,6 +1134,10 @@ Event.observe(window, 'load', function() {
       adjustDueDate()
     else if (label == 'New')
       setDueDate(null)
+    else if (label == 'Dispatched') {
+      const dispatchedCheckbox = findInput("Dispatched", "input[type=checkbox]");
+      dispatchedCheckbox.checked = true;
+    }
   })
 })
 


### PR DESCRIPTION
Check dispatched checkbox when Status changes to Dispatched. Will also be handled on backend for cases such as bulk editing. This is mostly to prevent confusion for TSO when a field randomly changes.