### PR TITLE
LIN-3411 Allow Parent Task Assignment on Single Redmine Issues

### DIFF
--- a/app/views/context_menus/issues.html.erb
+++ b/app/views/context_menus/issues.html.erb
@@ -4,12 +4,10 @@
 <% if !@issue.nil? -%>
   <li><%= context_menu_link l(:button_edit), {:controller => 'issues', :action => 'edit', :id => @issue},
           :class => 'icon-edit', :disabled => !@can[:edit] %></li>
-  <li><%= context_menu_link 'Bulk Edit', {:controller => 'issues', :action => 'bulk_edit', :ids => @issues.collect(&:id)},
-          :class => 'icon-edit', :disabled => !@can[:edit] %></li>
-<% else %>
-  <li><%= context_menu_link 'Bulk Edit', {:controller => 'issues', :action => 'bulk_edit', :ids => @issues.collect(&:id)},
-          :class => 'icon-edit', :disabled => !@can[:edit] %></li>
 <% end %>
+
+  <li><%= context_menu_link 'Bulk Edit', {:controller => 'issues', :action => 'bulk_edit', :ids => @issues.collect(&:id)},
+          :class => 'icon-edit', :disabled => !@can[:edit] %></li>
 
   <% if @allowed_statuses.present? %>
 	<li class="folder">			

--- a/app/views/context_menus/issues.html.erb
+++ b/app/views/context_menus/issues.html.erb
@@ -2,11 +2,13 @@
   <%= call_hook(:view_issues_context_menu_start, {:issues => @issues, :can => @can, :back => @back }) %>
 
 <% if !@issue.nil? -%>
-	<li><%= context_menu_link l(:button_edit), {:controller => 'issues', :action => 'edit', :id => @issue},
-	        :class => 'icon-edit', :disabled => !@can[:edit] %></li>
+  <li><%= context_menu_link l(:button_edit), {:controller => 'issues', :action => 'edit', :id => @issue},
+          :class => 'icon-edit', :disabled => !@can[:edit] %></li>
+  <li><%= context_menu_link 'Bulk Edit', {:controller => 'issues', :action => 'bulk_edit', :ids => @issues.collect(&:id)},
+          :class => 'icon-edit', :disabled => !@can[:edit] %></li>
 <% else %>
-	<li><%= context_menu_link l(:button_edit), {:controller => 'issues', :action => 'bulk_edit', :ids => @issues.collect(&:id)},
-	        :class => 'icon-edit', :disabled => !@can[:edit] %></li>
+  <li><%= context_menu_link 'Bulk Edit', {:controller => 'issues', :action => 'bulk_edit', :ids => @issues.collect(&:id)},
+          :class => 'icon-edit', :disabled => !@can[:edit] %></li>
 <% end %>
 
   <% if @allowed_statuses.present? %>


### PR DESCRIPTION
`Parent task` field does not show up on the edit page for single issues, but it does show up on the Bulk Edit page. This updates the context menu to allow bulk editing of single issues so that `Parent task` can be set.