### PR TITLE
LIN-3583 Redmine Due Date Weirdness

### DIFF
--- a/app/views/issues/_attributes.rhtml
+++ b/app/views/issues/_attributes.rhtml
@@ -1175,7 +1175,7 @@ Event.observe(window, 'load', function() {
     if (!isNew && !assigneeInput.options[assigneeInput.selectedIndex].label) {
       event.preventDefault();
       alert('Assignee needed before changing status. Try again.');
-      setDueDate(null)
+      return;
     } else if (trackerName === 'PokemonSupport') {
         if (
           selectedStatus === 'Feedback' &&
@@ -1183,6 +1183,7 @@ Event.observe(window, 'load', function() {
         ) {
           event.preventDefault();
           alert('Pending Reason required when Status = Feedback. Try again.');
+          return;
         }
 
         let closedStatuses = ['Closed', 'Canceled', 'Closed and Flagged']
@@ -1192,6 +1193,7 @@ Event.observe(window, 'load', function() {
         ) {
           event.preventDefault();
           alert('Root Cause required when Status one of Closed, Canceled or Closed & Flagged. Try again.');
+          return;
         }
     }
     
@@ -1201,6 +1203,7 @@ Event.observe(window, 'load', function() {
     ) {
       event.preventDefault();
       alert('Field tech needed before changing status to Dispatched. Try again')
+      return;
     }
 
     const partsStatus = partsStatusInput.value
@@ -1209,9 +1212,9 @@ Event.observe(window, 'load', function() {
       updateReturnVisitAndWaitingParts("NO")
     }
 
-    updateFieldVisits() // recalculating if there was an error
-    fieldVisits.disabled = false; // this allows the value to be saved
     localDueDateInput.replace(dueDateInput)
+    fieldVisits.disabled = false; // this allows the value to be saved
+    updateFieldVisits() // recalculating if there was an error
   })
 
   function addDaysToDueDate(days) {

--- a/app/views/issues/_attributes.rhtml
+++ b/app/views/issues/_attributes.rhtml
@@ -1166,16 +1166,17 @@ Event.observe(window, 'load', function() {
 
 
   $('issue-form').observe('submit', function(event) {
-    var assignee = findInput('Assignee', 'select')
+    const assigneeInput = findInput('Assignee', 'select');
     const statusInput = findInput('Status', 'select');
+    const fieldTechInput = findInput('Field tech', 'select');
     const isNew = statusInput.value === '1';
-    if (!isNew && !assignee.options[assignee.selectedIndex].label) {
+    const selectedStatus = statusInput.selectedOptions[0].textContent;
+
+    if (!isNew && !assigneeInput.options[assigneeInput.selectedIndex].label) {
       event.preventDefault();
       alert('Assignee needed before changing status. Try again.');
       setDueDate(null)
     } else if (trackerName === 'PokemonSupport') {
-        const selectedStatus = statusInput.selectedOptions[0].textContent
-        const fieldTech = findInput('Field tech', 'select')
         if (
           selectedStatus === 'Feedback' &&
             !findInput('Pending Reason', 'select').selectedOptions[0].textContent
@@ -1196,14 +1197,13 @@ Event.observe(window, 'load', function() {
     
     if (
       selectedStatus === 'Dispatched' &&
-      !fieldTech.options[fieldTech.selectedIndex].label
+      !fieldTechInput.options[fieldTechInput.selectedIndex].label
     ) {
       event.preventDefault();
       alert('Field tech needed before changing status to Dispatched. Try again')
     }
 
     const partsStatus = partsStatusInput.value
-    const selectedStatus = statusInput.selectedOptions[0].textContent
     let closedStatuses = ['Closed', 'Canceled', 'Closed and Flagged']
     if (closedStatuses.includes(selectedStatus) && !partsStatus) {
       updateReturnVisitAndWaitingParts("NO")

--- a/app/views/issues/_attributes.rhtml
+++ b/app/views/issues/_attributes.rhtml
@@ -1188,7 +1188,7 @@ Event.observe(window, 'load', function() {
 
         if (
           selectedStatus === 'Dispatched' &&
-          !fieldTech.options[fieldTech.selectedIndex].label
+          !fieldTechInput.options[fieldTechInput.selectedIndex].label
         ) {
           event.preventDefault();
           alert('Field tech needed before changing status to Dispatched. Try again');


### PR DESCRIPTION
The issue with Due Date being set to `--- !map:HashWithIndifferentAccess _local: ""` is due to the invisible date input that we're using. At the very end of the `onSubmit` handler, it calls `localDueDateInput.replace(dueDateInput)`, which restores the name of the Due Date field so that Redmine can process the new Due Date.

If there is any exception (such as using `selectedStatus` before its definition), that stops execution of the JavaScript function, which prevents the Due Date input from being renamed back to its original name from `<name>_local` (hence the `_local` in the bad value that was being set). Redmine interprets these additional underscores as a map value rather than just a string, and that's why we see the weird value for Due Dates.

In addition to fixing the exception, I also fixed validation. We should not prepare fields for submission when there is a validation error, as that breaks things (such as another bug with not being able to set the Due Date after an assignee validation failure). Now, it returns from the function and will only run the form cleanup when validation has passed.