### PR TITLE
LIN-3812 Bulk Edit requires Root Cause for Pokemon when Closing

### DIFF
--- a/app/views/issues/bulk_edit.rhtml
+++ b/app/views/issues/bulk_edit.rhtml
@@ -101,7 +101,7 @@
 	}
 	
 	function handleSubmit(e) {
-		const tracker = document.querySelectorAll("h1")?.[0].textContent.split("»")[1].trim();
+		const tracker = document.querySelector("h1")?.textContent?.split("»")?.[1]?.trim();
 		
 		if (tracker === "Pokemon") {
 			const closedStatuses = ["Closed", "Canceled"];

--- a/app/views/issues/bulk_edit.rhtml
+++ b/app/views/issues/bulk_edit.rhtml
@@ -89,3 +89,35 @@
 
 <p><%= submit_tag l(:button_submit) %></p>
 <% end %>
+
+<script>
+	function getSelectedValue(labelName) {
+		const label = Array.from(document.querySelectorAll("label"))
+			.find(label => label.textContent.trim() === labelName);
+		const selectElement = label?.nextElementSibling;
+		return (selectElement.selectedIndex > 1)
+			? selectElement.options[selectElement.selectedIndex]?.text
+			: undefined;
+	}
+	
+	function handleSubmit(e) {
+		const tracker = document.querySelectorAll("h1")?.[0].textContent.split("»")[1].trim();
+		
+		if (tracker === "Pokemon") {
+			const closedStatuses = ["Closed", "Canceled"];
+			const statusValue = getSelectedValue("Status");
+
+			if (closedStatuses.includes(statusValue)) {
+				const rootCauseValue = getSelectedValue("Root Cause");
+				if (!rootCauseValue) {
+					alert("Please select a Root Cause before closing tickets.");
+					e.preventDefault();
+					return;
+				}
+			}
+		}
+	}
+
+	const submitButton = document.querySelector("input[type='submit']");
+	submitButton.addEventListener("click", handleSubmit);
+</script>


### PR DESCRIPTION
Require `Root Cause` field to be set when using the Bulk Edit feature for Pokemon tickets when closing tickets.

There is the possibility of one or more of the tickets to already have a root cause, but this Jira only requires that bulk edit enforces Root Cause to be set when closing. If I need to account for existing Root Causes, I can make changes, but I think this is the simple solution we agreed on.

### Note on Tab vs Spaces
I know we typically use spaces instead of tabs, but this file uses tabs, so VSCode defaulted to using tabs for my changes. I can change it if necessary, but I'd want to reformat the whole file to be consistent.