### PR TITLE
LIN-3965 Add s3 plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /config/database.yml
 /config/email.yml
 /config/secrets.yml
+/config/s3.yml
 /config/initializers/session_store.rb
 /config/initializers/secret_token.rb
 /coverage

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 [submodule "plugins/redmine_datetime_custom_field"]
 	path = plugins/redmine_datetime_custom_field
 	url = https://github.com/ataraxis/redmine_datetime_custom_field
+
+[submodule "plugins/redmica_s3"]
+	path = plugins/redmica_s3
+	url = https://github.com/ataraxis/redmica_s3

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,4 +8,4 @@
 
 [submodule "plugins/redmica_s3"]
 	path = plugins/redmica_s3
-	url = https://github.com/ataraxis/redmica_s3
+	url = https://github.com/redmica/redmica_s3

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -12,6 +12,8 @@ USER root
 RUN apt-get update
 RUN apt-get install -y sqlite3 libsqlite3-dev build-essential libffi-dev libgmp-dev libyaml-dev ruby-dev
 
+RUN apt-get install -y jq curl
+
 USER redmine
 WORKDIR /usr/src/redmine
 
@@ -34,4 +36,11 @@ RUN apt-get clean
 RUN rm config/database.yml && \
     rm -rf db/
 
+# Copy and set up the custom entrypoint
+COPY scripts/entrypoint-wrapper.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint-wrapper.sh
+
 USER redmine
+
+ENTRYPOINT ["/usr/local/bin/entrypoint-wrapper.sh"]
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -12,8 +12,6 @@ USER root
 RUN apt-get update
 RUN apt-get install -y sqlite3 libsqlite3-dev build-essential libffi-dev libgmp-dev libyaml-dev ruby-dev
 
-RUN apt-get install -y jq curl
-
 USER redmine
 WORKDIR /usr/src/redmine
 

--- a/scripts/entrypoint-wrapper.sh
+++ b/scripts/entrypoint-wrapper.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Don't query metadata server unless running in ECS
+if [ "$RAILS_ENV" = "production" ]; then
+
+    if [ -z "$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" ]; then
+      echo "Error: AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not set."
+      echo "Make sure your Fargate task has an IAM role assigned to it."
+      exit 1
+    fi
+
+    CREDENTIALS_ENDPOINT="http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
+    CREDENTIALS=$(curl -s $CREDENTIALS_ENDPOINT)
+
+    export AWS_ACCESS_KEY_ID=$(echo $CREDENTIALS | jq -r '.AccessKeyId')
+    export AWS_SECRET_ACCESS_KEY=$(echo $CREDENTIALS | jq -r '.SecretAccessKey')
+    export AWS_SESSION_TOKEN=$(echo $CREDENTIALS | jq -r '.Token')
+
+elif [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "Warning: AWS_SECRET_ACCESS_KEY not set, S3 attachment storage disabled"
+
+elif [ -z "$WORKSPACE" ]; then
+    echo "Warning: WORKSPACE not set, S3 attachment storage disabled"
+
+else
+    export S3_BUCKET="$WORKSPACE-rds-redmine-files"
+fi
+
+if [ -n "$S3_BUCKET" ]; then
+    cat > /usr/src/redmine/config/s3.yml << EOF
+production:
+  access_key_id: "${AWS_ACCESS_KEY_ID}"
+  secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
+  session_token: "${AWS_SESSION_TOKEN}"
+  bucket: "${S3_BUCKET}"
+  folder: ""
+  region: "${AWS_REGION}"
+EOF
+fi
+
+exec /docker-entrypoint.sh "$@"

--- a/scripts/entrypoint-wrapper.sh
+++ b/scripts/entrypoint-wrapper.sh
@@ -1,41 +1,21 @@
 #!/bin/bash
 
-# Don't query metadata server unless running in ECS
-if [ "$RAILS_ENV" = "production" ]; then
 
-    if [ -z "$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" ]; then
-      echo "Error: AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not set."
-      echo "Make sure your Fargate task has an IAM role assigned to it."
-      exit 1
-    fi
-
-    CREDENTIALS_ENDPOINT="http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
-    CREDENTIALS=$(curl -s $CREDENTIALS_ENDPOINT)
-
-    export AWS_ACCESS_KEY_ID=$(echo $CREDENTIALS | jq -r '.AccessKeyId')
-    export AWS_SECRET_ACCESS_KEY=$(echo $CREDENTIALS | jq -r '.SecretAccessKey')
-    export AWS_SESSION_TOKEN=$(echo $CREDENTIALS | jq -r '.Token')
-
-elif [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-    echo "Warning: AWS_SECRET_ACCESS_KEY not set, S3 attachment storage disabled"
-
-elif [ -z "$WORKSPACE" ]; then
-    echo "Warning: WORKSPACE not set, S3 attachment storage disabled"
-
-else
-    export S3_BUCKET="$WORKSPACE-rds-redmine-files"
+if [ -z "$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" ]; then
+    echo "Error: AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not set."
+    echo "Make sure your Fargate task has an IAM role assigned to it."
+    exit 1
 fi
 
-if [ -n "$S3_BUCKET" ]; then
-    cat > /usr/src/redmine/config/s3.yml << EOF
+if [ -z "$S3_BUCKET" ]; then
+    echo "Error: S3_BUCKET is not set."
+    exit 1
+fi
+
+cat > /usr/src/redmine/config/s3.yml << EOF
 production:
-  access_key_id: "${AWS_ACCESS_KEY_ID}"
-  secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
-  session_token: "${AWS_SESSION_TOKEN}"
   bucket: "${S3_BUCKET}"
   folder: ""
-  region: "${AWS_REGION}"
 EOF
-fi
 
 exec /docker-entrypoint.sh "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -13,12 +13,8 @@ elif [ -z "$WORKSPACE" ]; then
 else
     cat > "$script_dir/../config/s3.yml" << EOF
 development:
-  access_key_id: "${AWS_ACCESS_KEY_ID}"
-  secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
-  session_token: "${AWS_SESSION_TOKEN}"
   bucket: "$WORKSPACE-rds-redmine-files"
   folder: ""
-  region: "${AWS_REGION}"
 EOF
 fi
 
@@ -29,6 +25,10 @@ docker run -it --rm \
     -p 3000:3000 \
     -e REDMINE_NO_DB_MIGRATE \
     -e RAILS_ENV \
+    -e AWS_ACCESS_KEY_ID \
+    -e AWS_SECRET_ACCESS_KEY \
+    -e AWS_SESSION_TOKEN \
+    -e AWS_REGION \
     -v $(pwd)/app:/usr/src/redmine/app \
     -v $(pwd)/config:/usr/src/redmine/config \
     --entrypoint rails \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,6 +4,24 @@ set -e
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$script_dir"/..
 
+if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "Warning: AWS_SECRET_ACCESS_KEY not set, S3 attachment storage disabled"
+
+elif [ -z "$WORKSPACE" ]; then
+    echo "Warning: WORKSPACE not set, S3 attachment storage disabled"
+
+else
+    cat > "$script_dir/../config/s3.yml" << EOF
+development:
+  access_key_id: "${AWS_ACCESS_KEY_ID}"
+  secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
+  session_token: "${AWS_SESSION_TOKEN}"
+  bucket: "$WORKSPACE-rds-redmine-files"
+  folder: ""
+  region: "${AWS_REGION}"
+EOF
+fi
+
 export REDMINE_NO_DB_MIGRATE=true
 export RAILS_ENV=development
 


### PR DESCRIPTION
~~Note that I had to [fork the redmica_s3 plugin](https://github.com/ataraxis/redmica_s3) in order to pass through the AWS session token. You can see those changes in that repo.~~

Despite what the documentation and code suggests, it's not actually necessary to configure the aws access key and secret in `s3.yml`. The sdk will automatically read those environment variables, and when it does, it automatically refreshes the session token. And letting it do that, a custom fork of the plugin repo is no longer necessary.