### PR TITLE
LIN-3964 More selective clean up

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get clean
 
 # Clean up temporary files
 RUN rm config/database.yml && \
-    rm -rf db/
+    find db/ -name "*.sqlite3*" -delete && \
+    rm -f db/schema.rb
 
 # Copy and set up the custom entrypoint
 COPY scripts/entrypoint-wrapper.sh /usr/local/bin/


### PR DESCRIPTION
The reason the migrations weren't running is because the `db/migrations` directory containing the migration files was axed as part of the sqlite db clean up.