### PR TITLE
LIN-4548 Add Logging

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,12 @@ module RedmineApp
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+      # Suppress verbose ActiveRecord SQL logs, but keep other logging
+      config.after_initialize do
+        if defined?(ActiveRecord::Base) && ActiveRecord::Base.logger
+          ActiveRecord::Base.logger.level = Logger::INFO
+        end
+      end
 
     # Adds `lib` to `config.autoload_paths` and `config.eager_load_paths`.
     config.autoload_lib(ignore: %w(tasks generators plugins))

--- a/plugins/zendesk_updater/lib/zendesk_updater/lambda_client.rb
+++ b/plugins/zendesk_updater/lib/zendesk_updater/lambda_client.rb
@@ -11,6 +11,8 @@ module ZendeskUpdater
       return if payload.nil?
 
       begin
+        puts "Invoking Lambda function #{function_name} with payload: #{payload}"
+        STDOUT.flush
         client = Aws::Lambda::Client.new()
         client.invoke(
           function_name: function_name,


### PR DESCRIPTION
Can't reproduce locally, so log payloads used to invoke the `pokemon-redmine` lambda so that source of issue Guli experiences can be determined.