### PR TITLE
LIN-4548 Deduplicaiton

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -2275,7 +2275,7 @@ class Issue < ApplicationRecord
     
     old_parent_id, new_parent_id = saved_change_to_parent_id
     
-    init_journal(User.current)
+    # Don't modify the existing journal - create a new one for field copying
     journal_notes = []
     
     if old_parent_id.present? && new_parent_id.blank?
@@ -2328,10 +2328,10 @@ class Issue < ApplicationRecord
     end
     
     if journal_notes.any?
+      # Create a separate journal for field copying operations
+      init_journal(User.current)
       current_journal.notes = journal_notes.join('. ')
       save!
-    else
-      clear_journal
     end
   end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -2275,7 +2275,7 @@ class Issue < ApplicationRecord
     
     old_parent_id, new_parent_id = saved_change_to_parent_id
     
-    # Don't modify the existing journal - create a new one for field copying
+    init_journal(User.current)
     journal_notes = []
     
     if old_parent_id.present? && new_parent_id.blank?
@@ -2328,10 +2328,10 @@ class Issue < ApplicationRecord
     end
     
     if journal_notes.any?
-      # Create a separate journal for field copying operations
-      init_journal(User.current)
       current_journal.notes = journal_notes.join('. ')
       save!
+    else
+      clear_journal
     end
   end
 end

--- a/plugins/zendesk_updater/lib/zendesk_updater/issue_callbacks.rb
+++ b/plugins/zendesk_updater/lib/zendesk_updater/issue_callbacks.rb
@@ -3,7 +3,6 @@ module ZendeskUpdater
     extend ActiveSupport::Concern
 
     included do
-      # Only trigger on creation, and only if no journal will be created
       after_commit :trigger_lambda_on_issue_creation, on: [:create]
     end
 
@@ -16,15 +15,6 @@ module ZendeskUpdater
       
       begin
         Rails.logger.info "Issue creation callback for issue #{id}"
-        
-        # Check if this issue creation will create a journal
-        # If journals exist, the JournalCallbacks will handle it
-        if journals.count > 0
-          Rails.logger.info "Issue #{id} has journals, skipping issue callback (journal callback will handle)"
-          return
-        end
-        
-        Rails.logger.info "Scheduling Zendesk update for new issue #{id} (no journals created)"
         
         # Use background job with small delay to ensure field copying is complete
         ZendeskUpdateJob.set(wait: 3.seconds).perform_later(id, nil)

--- a/plugins/zendesk_updater/lib/zendesk_updater/journal_callbacks.rb
+++ b/plugins/zendesk_updater/lib/zendesk_updater/journal_callbacks.rb
@@ -15,11 +15,15 @@ module ZendeskUpdater
           return unless journalized.project.identifier == 'pokemon'
           return unless ENV['WORKSPACE']
           
-          Rails.logger.info "Journal creation callback for issue #{journalized.id} journal #{id}"
+          # Prevent duplicate processing - Rails sometimes fires after_commit twice
+          # Use a short cache window to catch duplicates within ~100ms
+          cache_key = "zendesk_journal_processed_#{self.id}"
+          if Rails.cache.exist?(cache_key)
+            Rails.logger.info "[#{self.id}] Duplicate callback detected for journal #{self.id} - skipping"
+            return
+          end
           
-          # This handles both issue updates and issue creations that create journals
-          # The deduplication in LambdaClient will prevent double-calls if both 
-          # issue and journal callbacks fire for the same creation event
+          Rails.cache.write(cache_key, Time.current.to_i, expires_in: 10.seconds)
           
           Rails.logger.info "Scheduling Zendesk update for issue #{journalized.id} journal #{id}"
           

--- a/plugins/zendesk_updater/lib/zendesk_updater/journal_callbacks.rb
+++ b/plugins/zendesk_updater/lib/zendesk_updater/journal_callbacks.rb
@@ -19,7 +19,7 @@ module ZendeskUpdater
           # Use a short cache window to catch duplicates within ~100ms
           cache_key = "zendesk_journal_processed_#{self.id}"
           if Rails.cache.exist?(cache_key)
-            Rails.logger.info "[#{self.id}] Duplicate callback detected for journal #{self.id} - skipping"
+            Rails.logger.info "[#{self.id}] Duplicate callback detected - skipping"
             return
           end
           

--- a/plugins/zendesk_updater/lib/zendesk_updater/journal_callbacks.rb
+++ b/plugins/zendesk_updater/lib/zendesk_updater/journal_callbacks.rb
@@ -23,7 +23,7 @@ module ZendeskUpdater
             return
           end
           
-          Rails.cache.write(cache_key, Time.current.to_i, expires_in: 10.seconds)
+          Rails.cache.write(cache_key, true, expires_in: 10.seconds)
           
           Rails.logger.info "Scheduling Zendesk update for issue #{journalized.id} journal #{id}"
           


### PR DESCRIPTION
For some reason, Redmine is calling the `after_commit` callback twice, leading to the same journal with the same id to be processed twice with about a 100ms gap.

I've been trying to find the cause of this for most of today, but I've had no luck so far. I added back some deduplication logic for now since we're trying to get 10.4 out the door. I'd like to come back to it and figure out the root of the issue. If you have any ideas, let me know.

I also removed unnecessary logic for handling ticket creation, since the lambda relies on a null journal to create.