### PR TITLE
LIN-4804 Redmine Fixes related to Child Automation

### DIFF
--- a/plugins/zendesk_updater/lib/zendesk_updater/issue_callbacks.rb
+++ b/plugins/zendesk_updater/lib/zendesk_updater/issue_callbacks.rb
@@ -12,16 +12,14 @@ module ZendeskUpdater
       # Only process pokemon project issues
       return unless project.identifier == 'pokemon'
       return unless ENV['WORKSPACE']
-      
-      # Skip Updates from Zendesk
-      zendesk_ignore = false
+
+      # Skip Updates from Zendesk for specific parent issue
       if defined?(ZendeskUpdater::RequestContext)
-        zendesk_ignore = ZendeskUpdater::RequestContext.zendesk_ignore
-      end
-      
-      if zendesk_ignore
-        Rails.logger.info "[#{self.id}] Journal callback skipped - X-Zendesk-Ignore header set"
-        return
+        ignore_issue_id = ZendeskUpdater::RequestContext.zendesk_ignore_issue_id
+        if ignore_issue_id && ignore_issue_id == self.id
+          Rails.logger.info "[#{self.id}] Issue callback skipped - matches X-Zendesk-Ignore issue ID #{ignore_issue_id}"
+          return
+        end
       end
       
       begin

--- a/plugins/zendesk_updater/lib/zendesk_updater/journal_callbacks.rb
+++ b/plugins/zendesk_updater/lib/zendesk_updater/journal_callbacks.rb
@@ -15,15 +15,13 @@ module ZendeskUpdater
           return unless journalized.project.identifier == 'pokemon'
           return unless ENV['WORKSPACE']
 
-          # Skip Updates from Zendesk
-          zendesk_ignore = false
+          # Skip Updates from Zendesk for specific parent issue
           if defined?(ZendeskUpdater::RequestContext)
-            zendesk_ignore = ZendeskUpdater::RequestContext.zendesk_ignore
-          end
-          
-          if zendesk_ignore
-            Rails.logger.info "[#{self.id}] Journal callback skipped - X-Zendesk-Ignore header set"
-            return
+            ignore_issue_id = ZendeskUpdater::RequestContext.zendesk_ignore_issue_id
+            if ignore_issue_id && ignore_issue_id == journalized.id
+              Rails.logger.info "[#{self.id}] Journal callback skipped - journalized issue #{journalized.id} matches X-Zendesk-Ignore issue ID #{ignore_issue_id}"
+              return
+            end
           end
           
           # Prevent duplicate processing - Rails sometimes fires after_commit twice

--- a/plugins/zendesk_updater/lib/zendesk_updater/request_context.rb
+++ b/plugins/zendesk_updater/lib/zendesk_updater/request_context.rb
@@ -4,10 +4,11 @@ module ZendeskUpdater
   # Store request-scoped data using ActiveSupport::CurrentAttributes
   # This makes data available throughout the request lifecycle, including in model callbacks
   class RequestContext < ActiveSupport::CurrentAttributes
-    attribute :zendesk_ignore
+    attribute :zendesk_ignore_issue_id
 
     def self.set_from_headers(headers)
-      self.zendesk_ignore = headers['X-Zendesk-Ignore'].to_s.downcase == 'true'
+      ignore_header = headers['X-Zendesk-Ignore'].to_s.strip
+      self.zendesk_ignore_issue_id = ignore_header.present? ? ignore_header.to_i : nil
     end
   end
 end


### PR DESCRIPTION
Issue discovered when Guli was testing:
- closing parent ticket in Zendesk does not close children in Zendesk, only redmine

This is due to the X-Zendesk-Ignore header being set to true. The purpose of this header was to avoid sending redundant updates to Zendesk when the same change was triggered by Zendesk. However, setting it to true blocked propagation of child automation from Redmine to Zendesk.

This PR replaces the header's true value with the Redmine Issue ID of the parent that is being changed. This allows child updates to be sent to Zendesk while the parent updates (triggered by Zendesk) are not sent back.