### PR TITLE
LIN-4849 Remove conflict overwrite for KTs

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -566,8 +566,12 @@ class IssuesController < ApplicationController
     if issue_attributes && params[:conflict_resolution]
       case params[:conflict_resolution]
       when 'overwrite'
-        issue_attributes = issue_attributes.dup
-        issue_attributes.delete(:lock_version)
+        if User.current.allowed_to?(:overwrite_conflicting_updates, @issue.project)
+          issue_attributes = issue_attributes.dup
+          issue_attributes.delete(:lock_version)
+        end
+        # Without the permission lock_version is kept, so the save re-raises the
+        # conflict instead of clobbering the concurrent update.
       when 'add_notes'
         issue_attributes = issue_attributes.slice(:notes, :private_notes)
       when 'cancel'

--- a/app/views/issues/_attributes.html.erb
+++ b/app/views/issues/_attributes.html.erb
@@ -1119,7 +1119,7 @@ $(document).ready(function() {
   }
 
   function removeSendParts() {
-    if ($partsStatusInput.val() != "Pending") {
+    if ($partsStatusInput.length && $partsStatusInput.val() != "Pending") {
       const $select = findInput('Status', 'select');
       $select.find('option').each(function() {
         if ($(this).text() == 'Send Parts') {
@@ -1138,7 +1138,7 @@ $(document).ready(function() {
     const selectedStatus = $statusInput.find('option:selected').text();
     const closedStatuses = ['Closed', 'Canceled', 'Closed and Flagged'];
 
-    if (closedStatuses.includes(selectedStatus) && !partsStatus) {
+    if (closedStatuses.includes(selectedStatus) && $partsStatusInput.length && !partsStatus) {
       updateReturnVisitAndWaitingParts("NO");
     }
 

--- a/app/views/issues/_conflict.html.erb
+++ b/app/views/issues/_conflict.html.erb
@@ -22,7 +22,9 @@
   <% end %>
 </div>
 <p>
+  <% if User.current.allowed_to?(:overwrite_conflicting_updates, @issue.project) %>
   <label><%= radio_button_tag 'conflict_resolution', 'overwrite' %> <%= l(:text_issue_conflict_resolution_overwrite) %></label><br />
+  <% end %>
   <% if @issue.notes.present? %>
   <label><%= radio_button_tag 'conflict_resolution', 'add_notes' %> <%= l(:text_issue_conflict_resolution_add_notes) %></label><br />
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -538,6 +538,7 @@ en:
   permission_add_issues: Add issues
   permission_edit_issues: Edit issues
   permission_edit_own_issues: Edit own issues
+  permission_overwrite_conflicting_updates: Overwrite conflicting updates
   permission_copy_issues: Copy issues
   permission_manage_issue_relations: Manage issue relations
   permission_set_issues_private: Set issues public or private

--- a/lib/redmine/preparation.rb
+++ b/lib/redmine/preparation.rb
@@ -62,6 +62,7 @@ module Redmine
           map.permission :add_issues, {:issues => [:new, :create], :attachments => :upload}
           map.permission :edit_issues, {:issues => [:edit, :update, :bulk_edit, :bulk_update], :journals => [:new], :attachments => :upload}
           map.permission :edit_own_issues, {:issues => [:edit, :update, :bulk_edit, :bulk_update], :journals => [:new], :attachments => :upload}
+          map.permission :overwrite_conflicting_updates, {}, :require => :member
           map.permission :copy_issues, {:issues => [:new, :create, :bulk_edit, :bulk_update], :attachments => :upload}
           map.permission :manage_issue_relations, {:issue_relations => [:index, :show, :create, :destroy]}
           map.permission :manage_subtasks, {}


### PR DESCRIPTION
## Summary
- New `:overwrite_conflicting_updates` permission. The conflict dialog's "overwrite" radio and the controller's `lock_version` drop are gated on it, so KTs (FSR — which lacks the permission) can no longer clobber a concurrent update on save.
- Guards the issue-form Parts Status JS so a read-only field skips the Send Parts automation instead of acting as if empty.
- The permission is granted to non-FSR roles via the LIN-4849 evolve in mammoth (`k2/shared/schema`).

## Checklist
- [x] Dev testing completed
- [x] Added Deployment notes and testing instructions in Jira
